### PR TITLE
2:31 PDT 14-Aug: Stretch 1 seems to be gucci.

### DIFF
--- a/src/myjanktext.txt
+++ b/src/myjanktext.txt
@@ -1,0 +1,1 @@
+Overwrite YAAAH!


### PR DESCRIPTION
* Buffers for timestamps are now a less magical 32 bytes (vs 31).
* `/save` route saves request body to text file according to spec in readme.